### PR TITLE
CI: tag-based PyPI auto-release workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,14 +1,36 @@
-name: Deploy to PyPI
+name: Release to PyPI
 
 on:
-  workflow_run:
-    workflows: ["Test"]
-    types:
-      - completed
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  build-and-deploy:
+  test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install -r requirements.txt
+
+      - name: Test with pytest
+        run: python -m pytest
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
 
     steps:
       - uses: actions/checkout@v4
@@ -16,21 +38,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install build tools
         run: |
-          python -m pip install -U pip
-          python -m pip install -U setuptools build twine wheel
+          python -m pip install --upgrade pip
+          pip install build twine
 
       - name: Build package
-        run: |
-          python -m build
+        run: python -m build
 
       - name: Check package
-        run: |
-          twine check dist/*
+        run: twine check dist/*
 
-      - name: Publish package to PyPI
-        run: |
-          twine upload --skip-existing dist/* -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI
+        run: twine upload dist/* -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,9 +4,14 @@ on:
   push:
     branches:
       - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,9 +28,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade pip setuptools
           pip install -r requirements.txt
+
       - name: Test with pytest
         run: |
           python -m pytest


### PR DESCRIPTION
## Changes
- **test.yaml**: push/PR on `main` and `dev`、Python 3.11/3.12/3.13
- **deploy.yaml**: `v*` タグ push 時のみ実行
  - test job（全 Python バージョン）が通ってから publish
  - `PYPI_API_TOKEN` シークレットで PyPI にアップロード

## リリース手順（今後）
1. `pyproject.toml` のバージョンを更新して `main` にマージ
2. `git tag v1.x.x && git push origin v1.x.x`
3. GitHub Actions が自動でテスト → PyPI 公開